### PR TITLE
ensure that aws_alb_target_group.main depends on aws_alb.main

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -19,17 +19,21 @@ resource "aws_security_group" "ecs_alb" {
   }
 }
 
+resource "aws_alb" "main" {
+  name            = "${var.app_name}"
+  subnets         = "${var.subnets}"
+  security_groups = ["${aws_security_group.ecs_alb.id}"]
+}
+
 resource "aws_alb_target_group" "main" {
   name     = "${var.app_name}"
   port     = "${var.app_port}"
   protocol = "HTTP"
   vpc_id   = "${var.vpc}"
-}
 
-resource "aws_alb" "main" {
-  name            = "${var.app_name}"
-  subnets         = "${var.subnets}"
-  security_groups = ["${aws_security_group.ecs_alb.id}"]
+  depends_on = [
+    "aws_alb.main"
+  ]
 }
 
 resource "aws_alb_listener" "main" {


### PR DESCRIPTION
Running `terraform apply` I get the following error: 

```
Error: Error applying plan:

1 error(s) occurred:

* module.ecs_on_spotfleet.aws_ecs_service.main: 1 error(s) occurred:

* aws_ecs_service.main: InvalidParameterException: The target group with targetGroupArn arn:aws:elasticloadbalancing:us-east-1:897433496891:targetgroup/demo-app/ef73cdf1f63f2552 does not have an associated load balancer.
status code: 400, request id: 46b9d37d-00c9-11e8-a723-2d33e8496f1d "demo-app"
```

Looks like it's related to https://github.com/hashicorp/terraform/issues/12634.

This PR resequences the resources and adds the `depends_on` declaration as recommended in that thread.  

