### PR TITLE
Don't override the root module's provider configuration

### DIFF
--- a/cli/template.tf.erb
+++ b/cli/template.tf.erb
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
 module "ecs_on_spotfleet" {
   source = "github.com/wata727/tf_aws_ecs_on_spotfleet"
 

--- a/cli/template.tf.erb
+++ b/cli/template.tf.erb
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "${var.region}"
+  region = "<%= config[:region] %>"
 }
 
 module "ecs_on_spotfleet" {

--- a/cli/wizard.rb
+++ b/cli/wizard.rb
@@ -6,7 +6,8 @@ class Wizard < Thor
 
   desc 'wizard generate', 'generate template for quick start'
   def generate
-    client = Aws::EC2::Client.new(region: 'us-east-1')
+    region = 'us-east-1'
+    client = Aws::EC2::Client.new(region: region)
     ec2 = Aws::EC2::Resource.new(client: client)
 
     default_vpc_id = ec2.vpcs(filters: [{ name: 'isDefault', values: [true.to_s] }]).first.id
@@ -24,7 +25,7 @@ class Wizard < Thor
       spot_infos << { subnet: subnet.id, price: res.spot_price_history.first.spot_price }
     end
 
-    template 'template.tf.erb', 'template.tf', { vpc_id: default_vpc_id, spot_infos: spot_infos, key_name: key.name }
+    template 'template.tf.erb', 'template.tf', { region: region, vpc_id: default_vpc_id, spot_infos: spot_infos, key_name: key.name }
   end
 
   desc 'wizard g', 'alias for wizard generate'

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  region = "${var.region}"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -13,13 +13,6 @@ variable "key_name" {
   description = "Name of key pair for SSH login to ECS cluster instances"
 }
 
-// If you use other than us-east-1, need to change the following:
-
-variable "region" {
-  description = "Region for ECS cluster"
-  default     = "us-east-1"
-}
-
 variable "ami" {
   description = "ECS cluster instance AMI id, default is Amazon ECS-optimized AMI in us-east-1"
   default     = "ami-eca289fb"


### PR DESCRIPTION
From the [Terraform Docs](https://www.terraform.io/docs/modules/usage.html)

> In a configuration with multiple modules, there are some special considerations for how resources are associated with provider configurations.

> While in principle provider blocks can appear in any module, it is recommended that they be placed only in the root module of a configuration, since this approach allows users to configure providers just once and re-use them across all descendent modules.

To make this module usable with root provider configurations, I propose we move the provider config to the CLI directory and remove the `main.tf` provider config.


